### PR TITLE
[TASK] Add TYPO3 v14-compatible v13 upgrade wizard set to core_upgrader

### DIFF
--- a/Classes/Upgrades/v13/BackendGroupsExplicitAllowDenyMigration.php
+++ b/Classes/Upgrades/v13/BackendGroupsExplicitAllowDenyMigration.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use Symfony\Component\Console\Output\OutputInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Upgrades\ChattyInterface;
+use TYPO3\CMS\Core\Upgrades\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @since 12.1
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('backendGroupsExplicitAllowDenyMigration')]
+final class BackendGroupsExplicitAllowDenyMigration implements UpgradeWizardInterface, ChattyInterface
+{
+    private const TABLE_NAME = 'be_groups';
+
+    private OutputInterface $output;
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    public function getTitle(): string
+    {
+        return 'Migrate backend groups "explicit_allowdeny" field to simplified format.';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Backend groups field "explicit_allowdeny" storage format has been simplified. This updates all be_groups records.';
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    public function updateNecessary(): bool
+    {
+        $needsUpdate = false;
+        $queryBuilder = $this->getPreparedQueryBuilder();
+        $result = $queryBuilder->select('uid', 'explicit_allowdeny')->from(self::TABLE_NAME)->executeQuery();
+        while ($row = $result->fetchAssociative()) {
+            // Target is a comma separated list of colon seperated "tableName:fieldName:valueName"
+            // If there are four colon fields, the update should remove the last one.
+            $tuples = GeneralUtility::trimExplode(',', (string)$row['explicit_allowdeny'], true);
+            foreach ($tuples as $tuple) {
+                if (count(GeneralUtility::trimExplode(':', $tuple, true)) > 3) {
+                    $needsUpdate = true;
+                    $result->free();
+                    break 2;
+                }
+            }
+        }
+        return $needsUpdate;
+    }
+
+    public function executeUpdate(): bool
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME);
+        $queryBuilder = $this->getPreparedQueryBuilder();
+        $result = $queryBuilder->select('uid', 'explicit_allowdeny')->from(self::TABLE_NAME)->executeQuery();
+        $success = true;
+        while ($row = $result->fetchAssociative()) {
+            $tuples = GeneralUtility::trimExplode(',', (string)$row['explicit_allowdeny'], true);
+            $newTuples = [];
+            $updateNeeded = false;
+            foreach ($tuples as $tuple) {
+                $explodedTuples = GeneralUtility::trimExplode(':', $tuple, true);
+                if (count($explodedTuples) > 3) {
+                    $updateNeeded = true;
+                    $newTupleString  = implode(':', array_chunk($explodedTuples, 3, true)[0]);
+                    if ($explodedTuples[3] === 'DENY') {
+                        // We can't migrate 'explicitDeny' values. Fully remove that tuple and add an output note.
+                        $this->output->writeln(
+                            '<error>Access rights setup "Explicitly allow field values" of be_groups row uid "' . $row['uid'] . '"'
+                            . ' had explicit DENY set for the table/field/value combination "' . $newTupleString . '".'
+                            . ' This is not allowed anymore. This be_groups row needs a manual update to fix access rights.</error>'
+                        );
+                        $success = false;
+                        continue;
+                    }
+                    $newTuples[] = $newTupleString;
+                } else {
+                    $newTuples[] = $tuple;
+                }
+            }
+            if ($updateNeeded) {
+                $connection->update(
+                    self::TABLE_NAME,
+                    ['explicit_allowdeny' => implode(',', $newTuples)],
+                    ['uid' => (int)$row['uid']],
+                    ['explicit_allowdeny' => Connection::PARAM_STR]
+                );
+            }
+        }
+        return $success;
+    }
+
+    public function setOutput(OutputInterface $output): void
+    {
+        $this->output = $output;
+    }
+
+    private function getPreparedQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll();
+        return $queryBuilder->from(self::TABLE_NAME);
+    }
+
+    private function getConnectionPool(): ConnectionPool
+    {
+        return $this->connectionPool;
+    }
+}

--- a/Classes/Upgrades/v13/BackendModulePermissionMigration.php
+++ b/Classes/Upgrades/v13/BackendModulePermissionMigration.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use TYPO3\CMS\Backend\Module\ModuleRegistry;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @since 12.1
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('backendModulePermission')]
+class BackendModulePermissionMigration implements UpgradeWizardInterface
+{
+    protected array $aliases = [];
+
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+        $this->aliases = GeneralUtility::makeInstance(ModuleRegistry::class)->getModuleAliases();
+    }
+
+    public function getTitle(): string
+    {
+        return 'Migrate backend user and groups to new module names.';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Update backend user and groups to migrate to possible new module names.';
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->aliases !== []
+            && (
+                $this->hasRecordsToUpdate('be_groups', 'groupMods')
+                || $this->hasRecordsToUpdate('be_users', 'userMods')
+            );
+    }
+
+    public function executeUpdate(): bool
+    {
+        $this->updateRecords('be_groups', 'groupMods');
+        $this->updateRecords('be_users', 'userMods');
+        return true;
+    }
+
+    protected function hasRecordsToUpdate(string $table, string $field): bool
+    {
+        $queryBuilder = $this->getPreparedQueryBuilder($table, $field);
+        $statement = $queryBuilder->select($field)->executeQuery();
+        $aliasIdentifiers = array_keys($this->aliases);
+        while ($record = $statement->fetchAssociative()) {
+            $selectedModules = GeneralUtility::trimExplode(',', $record[$field], true);
+            if (array_intersect($selectedModules, $aliasIdentifiers) !== []) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected function updateRecords(string $table, string $field): void
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable($table);
+        $statement = $this->getPreparedQueryBuilder($table, $field)->select('uid', $field)->executeQuery();
+        $aliasIdentifiers = array_keys($this->aliases);
+        while ($record = $statement->fetchAssociative()) {
+            $selectedModules = GeneralUtility::trimExplode(',', $record[$field], true);
+            if (array_intersect($selectedModules, $aliasIdentifiers) === []) {
+                continue;
+            }
+            $newModules = [];
+            foreach ($selectedModules as $moduleIdentifier) {
+                $newModules[] = $this->aliases[$moduleIdentifier] ?? $moduleIdentifier;
+            }
+            $connection->update($table, [$field => implode(',', $newModules)], ['uid' => $record['uid']]);
+        }
+    }
+
+    protected function getPreparedQueryBuilder(string $table, string $field): QueryBuilder
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->from($table)
+            ->where(
+                $queryBuilder->expr()->isNotNull($field),
+                $queryBuilder->expr()->neq($field, $queryBuilder->createNamedParameter('')),
+            );
+
+        return $queryBuilder;
+    }
+
+    protected function getConnectionPool(): ConnectionPool
+    {
+        return $this->connectionPool;
+    }
+}

--- a/Classes/Upgrades/v13/DatabaseRowsUpdateWizard.php
+++ b/Classes/Upgrades/v13/DatabaseRowsUpdateWizard.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use Doctrine\DBAL\ConnectionException;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Registry;
+use TYPO3\CMS\Core\Upgrades\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Core\Upgrades\RepeatableInterface;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\v13\Core\Upgrades\RowUpdater\RowUpdaterInterface;
+use TYPO3\CMS\v13\Core\Upgrades\RowUpdater\SysRedirectRootPageMoveMigration;
+
+/**
+ * This is a generic updater to migrate content of TCA rows.
+ *
+ * Multiple classes implementing interface "RowUpdaterInterface" can be
+ * registered here, each for a specific update purpose.
+ *
+ * The updater fetches each row of all TCA registered tables and
+ * visits the client classes who may modify the row content.
+ *
+ * The updater remembers for each class if it run through, so the updater
+ * will be shown again if a new updater class is registered that has not
+ * been run yet.
+ *
+ * A start position pointer is stored in the registry that is updated during
+ * the run process, so if for instance the PHP process runs into a timeout,
+ * the job can restart at the position it stopped.
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('databaseRowsUpdateWizard')]
+class DatabaseRowsUpdateWizard implements UpgradeWizardInterface, RepeatableInterface
+{
+    /**
+     * @var array Single classes that may update rows
+     */
+    protected $rowUpdater = [
+        SysRedirectRootPageMoveMigration::class,
+    ];
+    public function __construct(private readonly Registry $registry, private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    /**
+     * @internal
+     * @return string[]
+     */
+    public function getAvailableRowUpdater(): array
+    {
+        return $this->rowUpdater;
+    }
+
+    /**
+     * @return string Title of this updater
+     */
+    public function getTitle(): string
+    {
+        return 'Execute database migrations on single rows';
+    }
+
+    /**
+     * @return string Longer description of this updater
+     * @throws \RuntimeException
+     */
+    public function getDescription(): string
+    {
+        $rowUpdaterNotExecuted = $this->getRowUpdatersToExecute();
+        $description = 'Row updaters that have not been executed:';
+        foreach ($rowUpdaterNotExecuted as $rowUpdateClassName) {
+            $rowUpdater = GeneralUtility::makeInstance($rowUpdateClassName);
+            if (!$rowUpdater instanceof RowUpdaterInterface) {
+                throw new \RuntimeException(
+                    'Row updater must implement RowUpdaterInterface',
+                    1484066647
+                );
+            }
+            $description .= LF . $rowUpdater->getTitle();
+        }
+        return $description;
+    }
+
+    /**
+     * @return bool True if at least one row updater is not marked done
+     */
+    public function updateNecessary(): bool
+    {
+        return $this->getRowUpdatersToExecute() !== [];
+    }
+
+    /**
+     * @return string[] All new fields and tables must exist
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    /**
+     * Performs the configuration update.
+     *
+     * @throws ConnectionException
+     * @throws \Exception
+     */
+    public function executeUpdate(): bool
+    {
+        $registry = $this->registry;
+
+        // If rows from the target table that is updated and the sys_registry table are on the
+        // same connection, the row update statement and sys_registry position update will be
+        // handled in a transaction to have an atomic operation in case of errors during execution.
+        $connectionPool = $this->connectionPool;
+        $connectionForSysRegistry = $connectionPool->getConnectionForTable('sys_registry');
+
+        /** @var RowUpdaterInterface[] $rowUpdaterInstances */
+        $rowUpdaterInstances = [];
+        // Single row updater instances are created only once for this method giving
+        // them a chance to set up local properties during hasPotentialUpdateForTable()
+        // and using that in updateTableRow()
+        foreach ($this->getRowUpdatersToExecute() as $rowUpdater) {
+            $rowUpdaterInstance = GeneralUtility::makeInstance($rowUpdater);
+            if (!$rowUpdaterInstance instanceof RowUpdaterInterface) {
+                throw new \RuntimeException(
+                    'Row updater must implement RowUpdaterInterface',
+                    1484071612
+                );
+            }
+            $rowUpdaterInstances[] = $rowUpdaterInstance;
+        }
+
+        // Scope of the row updater is to update all rows that have TCA,
+        // our list of tables is just the list of loaded TCA tables.
+        /** @var string[] $listOfAllTables */
+        $listOfAllTables = array_keys($GLOBALS['TCA']);
+
+        // In case the PHP ended for whatever reason, fetch the last position from registry
+        // and throw away all tables before that start point.
+        sort($listOfAllTables);
+        reset($listOfAllTables);
+        $firstTable = current($listOfAllTables) ?: '';
+        $startPosition = $this->getStartPosition($firstTable);
+        foreach ($listOfAllTables as $key => $table) {
+            if ($table === $startPosition['table']) {
+                break;
+            }
+            unset($listOfAllTables[$key]);
+        }
+
+        // Ask each row updater if it potentially has field updates for rows of a table
+        $tableToUpdaterList = [];
+        foreach ($listOfAllTables as $table) {
+            foreach ($rowUpdaterInstances as $updater) {
+                if ($updater->hasPotentialUpdateForTable($table)) {
+                    if (!isset($tableToUpdaterList[$table]) || !is_array($tableToUpdaterList[$table])) {
+                        $tableToUpdaterList[$table] = [];
+                    }
+                    $tableToUpdaterList[$table][] = $updater;
+                }
+            }
+        }
+
+        // Iterate through all rows of all tables that have potential row updaters attached,
+        // feed each single row to each updater and finally update each row in database if
+        // a row updater changed a fields
+        foreach ($tableToUpdaterList as $table => $updaters) {
+            /** @var RowUpdaterInterface[] $updaters */
+            $connectionForTable = $connectionPool->getConnectionForTable($table);
+            $queryBuilder = $connectionPool->getQueryBuilderForTable($table);
+            $queryBuilder->getRestrictions()->removeAll();
+            $queryBuilder->select('*')
+                ->from($table)
+                ->orderBy('uid');
+            if ($table === $startPosition['table']) {
+                $queryBuilder->where(
+                    $queryBuilder->expr()->gt('uid', $queryBuilder->createNamedParameter($startPosition['uid']))
+                );
+            }
+            $statement = $queryBuilder->executeQuery();
+            $rowCountWithoutUpdate = 0;
+            while ($row = $statement->fetchAssociative()) {
+                $rowBefore = $row;
+                foreach ($updaters as $updater) {
+                    $row = $updater->updateTableRow($table, $row);
+                }
+                $updatedFields = array_diff_assoc($row, $rowBefore);
+                if ($updatedFields === []) {
+                    // Updaters changed no field of that row
+                    $rowCountWithoutUpdate++;
+                    if ($rowCountWithoutUpdate >= 200) {
+                        // Update startPosition if there were many rows without data change
+                        $startPosition = [
+                            'table' => $table,
+                            'uid' => $row['uid'],
+                        ];
+                        $registry->set('installUpdateRows', 'rowUpdatePosition', $startPosition);
+                        $rowCountWithoutUpdate = 0;
+                    }
+                } else {
+                    $rowCountWithoutUpdate = 0;
+                    $startPosition = [
+                        'table' => $table,
+                        'uid' => $rowBefore['uid'],
+                    ];
+                    if ($connectionForSysRegistry === $connectionForTable) {
+                        // Target table and sys_registry table are on the same connection, use a transaction
+                        $connectionForTable->beginTransaction();
+                        try {
+                            $this->updateOrDeleteRow(
+                                $connectionForTable,
+                                $connectionForTable,
+                                $table,
+                                (int)$rowBefore['uid'],
+                                $updatedFields,
+                                $startPosition
+                            );
+                            $connectionForTable->commit();
+                        } catch (\Exception $up) {
+                            $connectionForTable->rollBack();
+                            throw $up;
+                        }
+                    } else {
+                        // Different connections for table and sys_registry.
+                        // So, execute two distinct queries and hope for the best.
+                        $this->updateOrDeleteRow(
+                            $connectionForTable,
+                            $connectionForSysRegistry,
+                            $table,
+                            (int)$rowBefore['uid'],
+                            $updatedFields,
+                            $startPosition
+                        );
+                    }
+                }
+            }
+        }
+
+        // Ready with updates, remove position information from sys_registry
+        $registry->remove('installUpdateRows', 'rowUpdatePosition');
+        // Mark row updaters that were executed as done
+        foreach ($rowUpdaterInstances as $updater) {
+            $this->setRowUpdaterExecuted($updater);
+        }
+
+        return true;
+    }
+
+    /**
+     * Return an array of class names that are not yet marked as done.
+     *
+     * @return array Class names
+     */
+    protected function getRowUpdatersToExecute(): array
+    {
+        $doneRowUpdater = $this->registry->get('installUpdateRows', 'rowUpdatersDone', []);
+        return array_diff($this->rowUpdater, $doneRowUpdater);
+    }
+
+    /**
+     * Mark a single updater as done
+     */
+    protected function setRowUpdaterExecuted(RowUpdaterInterface $updater)
+    {
+        $registry = $this->registry;
+        $doneRowUpdater = $registry->get('installUpdateRows', 'rowUpdatersDone', []);
+        $doneRowUpdater[] = $updater::class;
+        $registry->set('installUpdateRows', 'rowUpdatersDone', $doneRowUpdater);
+    }
+
+    /**
+     * Return an array with table / uid combination that specifies the start position the
+     * update row process should start with.
+     *
+     * @param string $firstTable Table name of the first TCA in case the start position needs to be initialized
+     * @return array New start position
+     */
+    protected function getStartPosition(string $firstTable): array
+    {
+        $registry = $this->registry;
+        $startPosition = $registry->get('installUpdateRows', 'rowUpdatePosition', []);
+        if (empty($startPosition)) {
+            $startPosition = [
+                'table' => $firstTable,
+                'uid' => 0,
+            ];
+            $registry->set('installUpdateRows', 'rowUpdatePosition', $startPosition);
+        }
+        return $startPosition;
+    }
+
+    protected function updateOrDeleteRow(Connection $connectionForTable, Connection $connectionForSysRegistry, string $table, int $uid, array $updatedFields, array $startPosition): void
+    {
+        $deleteField = $GLOBALS['TCA'][$table]['ctrl']['delete'] ?? null;
+        if ($deleteField === null && isset($updatedFields['deleted']) && $updatedFields['deleted'] === 1) {
+            $connectionForTable->delete(
+                $table,
+                [
+                    'uid' => $uid,
+                ]
+            );
+        } else {
+            $connectionForTable->update(
+                $table,
+                $updatedFields,
+                [
+                    'uid' => $uid,
+                ]
+            );
+        }
+        $connectionForSysRegistry->update(
+            'sys_registry',
+            [
+                'entry_value' => serialize($startPosition),
+            ],
+            [
+                'entry_namespace' => 'installUpdateRows',
+                'entry_key' => 'rowUpdatePosition',
+            ],
+            [
+                // Needs to be declared LOB, so MSSQL can handle the conversion from string (nvarchar) to blob (varbinary)
+                'entry_value' => Connection::PARAM_LOB,
+                'entry_namespace' => Connection::PARAM_STR,
+                'entry_key' => Connection::PARAM_STR,
+            ]
+        );
+    }
+}

--- a/Classes/Upgrades/v13/MigrateSiteSettingsConfigUpdate.php
+++ b/Classes/Upgrades/v13/MigrateSiteSettingsConfigUpdate.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use TYPO3\CMS\Core\Configuration\Exception\SiteConfigurationWriteException;
+use TYPO3\CMS\Core\Configuration\SiteConfiguration;
+use TYPO3\CMS\Core\Configuration\SiteWriter;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @since 12.1
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ *
+ * The upgrade wizard cuts the settings part of the config.yaml and moves it into settings.yaml.
+ */
+#[UpgradeWizard('migrateSiteSettings')]
+class MigrateSiteSettingsConfigUpdate implements UpgradeWizardInterface
+{
+    protected const SETTINGS_FILENAME = 'settings.yaml';
+
+    protected ?SiteConfiguration $siteConfiguration = null;
+    protected ?SiteWriter $siteWriter = null;
+    protected array $sitePathsToMigrate = [];
+
+    public function __construct()
+    {
+        $this->siteConfiguration = GeneralUtility::makeInstance(SiteConfiguration::class);
+        $this->siteWriter = GeneralUtility::makeInstance(SiteWriter::class);
+        $this->sitePathsToMigrate = $this->getSitePathsToMigrate();
+    }
+
+    public function getTitle(): string
+    {
+        return 'Migrate site settings to separate file';
+    }
+
+    public function getDescription(): string
+    {
+        return
+            'If site settings exist in a config.yaml file, this wizard migrates them to a dedicated settings.yaml file. '
+            . 'Please note that you should remove them from your existing config manually.';
+    }
+
+    public function executeUpdate(): bool
+    {
+        try {
+            foreach ($this->sitePathsToMigrate as $siteIdentifier => $settings) {
+                $this->siteWriter->writeSettings($siteIdentifier, $settings);
+            }
+        } catch (SiteConfigurationWriteException) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * if the settings file does not exist an update is considered as necessary
+     */
+    public function updateNecessary(): bool
+    {
+        return $this->sitePathsToMigrate !== [];
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [];
+    }
+
+    /**
+     * returns an array of siteconfigs, if they don't have a corresponding settings file
+     */
+    protected function getSitePathsToMigrate(): array
+    {
+        $settingsCollection = [];
+        foreach ($this->siteConfiguration->getAllSiteConfigurationPaths() as $siteIdentifier => $configurationPath) {
+            // Ensure site identifier is a string, even if it only consists of digits
+            $siteIdentifier = (string)$siteIdentifier;
+            // settings.yaml already exists, skip
+            if (file_exists($configurationPath . '/' . self::SETTINGS_FILENAME)) {
+                continue;
+            }
+            // Check if the site has any settings
+            $siteConfiguration = $this->siteConfiguration->load($siteIdentifier);
+            if (!isset($siteConfiguration['settings'])) {
+                continue;
+            }
+            $settingsCollection[$siteIdentifier] = $siteConfiguration['settings'];
+        }
+        return $settingsCollection;
+    }
+}

--- a/Classes/Upgrades/v13/RowUpdater/RowUpdaterInterface.php
+++ b/Classes/Upgrades/v13/RowUpdater/RowUpdaterInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades\RowUpdater;
+
+/**
+ * Interface each single row updater must implement.
+ */
+interface RowUpdaterInterface
+{
+    /**
+     * Get a description of this single row updater
+     */
+    public function getTitle(): string;
+
+    /**
+     * Return true if this row updater may have updates for given table rows.
+     *
+     * @param string $tableName Given table
+     */
+    public function hasPotentialUpdateForTable(string $tableName): bool;
+
+    /**
+     * Update a single row from a table.
+     *
+     * @param string $tableName Given table
+     * @param array $row Given row
+     * @return array Potentially modified row
+     */
+    public function updateTableRow(string $tableName, array $row): array;
+}

--- a/Classes/Upgrades/v13/RowUpdater/SysRedirectRootPageMoveMigration.php
+++ b/Classes/Upgrades/v13/RowUpdater/SysRedirectRootPageMoveMigration.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades\RowUpdater;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Exception\SiteNotFoundException;
+use TYPO3\CMS\Core\Site\SiteFinder;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * @since 12.1
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+class SysRedirectRootPageMoveMigration implements RowUpdaterInterface
+{
+    private const TABLE_NAME = 'sys_redirect';
+
+    private readonly array $rootPageIds;
+
+    private readonly ConnectionPool $connectionPool;
+
+    private readonly SiteFinder $siteFinder;
+
+    public function __construct(
+        ?ConnectionPool $connectionPool = null,
+        ?SiteFinder $siteFinder = null
+    ) {
+        $this->connectionPool = $connectionPool ?? GeneralUtility::makeInstance(ConnectionPool::class);
+        $this->siteFinder = $siteFinder ?? GeneralUtility::makeInstance(SiteFinder::class);
+        $this->rootPageIds = $this->getRootPageIds();
+    }
+
+    public function getTitle(): string
+    {
+        return 'Move "sys_redirect" records to site config root pages.';
+    }
+
+    public function hasPotentialUpdateForTable(string $tableName): bool
+    {
+        if ($tableName !== self::TABLE_NAME || !$this->sysRedirectsTableExists()) {
+            return false;
+        }
+        $rootPageIds = $this->getRootPageIds();
+        $queryBuilder = $this->getPreparedQueryBuilder();
+        $andWhereConditions = $queryBuilder->expr()->and($queryBuilder->expr()->neq('pid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)));
+        if ($rootPageIds !== []) {
+            $andWhereConditions = $andWhereConditions->with($queryBuilder->expr()->notIn('pid', $queryBuilder->createNamedParameter($rootPageIds, Connection::PARAM_INT_ARRAY)));
+        }
+        $numberOfNonRootPageRedirectRecords = (int)$queryBuilder
+            ->count('uid')
+            ->from(self::TABLE_NAME)
+            ->where($andWhereConditions)
+            ->executeQuery()
+            ->fetchOne();
+        return $numberOfNonRootPageRedirectRecords > 0;
+    }
+
+    public function updateTableRow(string $tableName, array $row): array
+    {
+        if ($tableName !== self::TABLE_NAME) {
+            return $row;
+        }
+        $pageId = (int)$row['pid'];
+        if ($pageId === 0 || in_array($pageId, $this->rootPageIds, true)) {
+            return $row;
+        }
+        try {
+            $rootPageId = $this->siteFinder->getSiteByPageId($pageId)->getRootPageId();
+        } catch (SiteNotFoundException) {
+            // Move redirects without proper site config root page to top tree page.
+            $rootPageId = 0;
+        }
+        if ($rootPageId !== $pageId) {
+            $row['pid'] = $rootPageId;
+        }
+        return $row;
+    }
+
+    private function getRootPageIds(): array
+    {
+        $rootPageIds = [];
+        $sites = $this->siteFinder->getAllSites();
+        foreach ($sites as $site) {
+            if (!in_array($site->getRootPageId(), $rootPageIds, true)) {
+                $rootPageIds[] = $site->getRootPageId();
+            }
+        }
+        return $rootPageIds;
+    }
+
+    private function sysRedirectsTableExists(): bool
+    {
+        $schemaManager = $this->connectionPool->getConnectionForTable(self::TABLE_NAME)->createSchemaManager();
+        return $schemaManager->tablesExist([self::TABLE_NAME]);
+    }
+
+    private function getPreparedQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll();
+        return $queryBuilder;
+    }
+}

--- a/Classes/Upgrades/v13/SysFileCollectionIdentifierMigration.php
+++ b/Classes/Upgrades/v13/SysFileCollectionIdentifierMigration.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Upgrades\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+
+/**
+ * @since 12.4
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('sysFileCollectionIdentifierMigration')]
+class SysFileCollectionIdentifierMigration implements UpgradeWizardInterface
+{
+    protected const TABLE_NAME = 'sys_file_collection';
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    public function getTitle(): string
+    {
+        return 'Migrate storage and folder to the new folder_identifier property of the "sys_file_collection" table.';
+    }
+
+    public function getDescription(): string
+    {
+        return 'The "sys_file_collection" table has a new identifier property which is used to identify the mount point. This update migrates the properties "storage" and "folder" to the new "folder_identifier" property.';
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->columnsExistInTable() && $this->hasRecordsToUpdate();
+    }
+
+    public function executeUpdate(): bool
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME);
+
+        foreach ($this->getRecordsToUpdate() as $record) {
+            $connection->update(
+                self::TABLE_NAME,
+                ['folder_identifier' => $record['storage'] . ':' . $record['folder']],
+                ['uid' => (int)$record['uid']]
+            );
+        }
+
+        return true;
+    }
+
+    protected function columnsExistInTable(): bool
+    {
+        $schemaManager = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME)->createSchemaManager();
+
+        $tableColumns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        foreach (['storage', 'folder', 'folder_identifier'] as $column) {
+            if (!isset($tableColumns[$column])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function hasRecordsToUpdate(): bool
+    {
+        return (bool)$this->getPreparedQueryBuilder()->count('uid')->executeQuery()->fetchOne();
+    }
+
+    protected function getRecordsToUpdate(): array
+    {
+        return $this->getPreparedQueryBuilder()->select('uid', 'storage', 'folder', 'folder_identifier')->executeQuery()->fetchAllAssociative();
+    }
+
+    protected function getPreparedQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->gt('storage', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->neq('folder', $queryBuilder->createNamedParameter('')),
+                $queryBuilder->expr()->or(
+                    $queryBuilder->expr()->eq('folder_identifier', $queryBuilder->createNamedParameter('')),
+                    $queryBuilder->expr()->isNull('folder_identifier'),
+                ),
+                $queryBuilder->expr()->eq('type', $queryBuilder->createNamedParameter('folder'))
+            );
+
+        return $queryBuilder;
+    }
+
+    protected function getConnectionPool(): ConnectionPool
+    {
+        return $this->connectionPool;
+    }
+}

--- a/Classes/Upgrades/v13/SysFileMimeTypeMigration.php
+++ b/Classes/Upgrades/v13/SysFileMimeTypeMigration.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Resource\MimeTypeCompatibilityTypeGuesser;
+use TYPO3\CMS\Core\Upgrades\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Core\Upgrades\RepeatableInterface;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+
+/**
+ * @since 12.4
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('sysFileMimeTypeMigration')]
+class SysFileMimeTypeMigration implements UpgradeWizardInterface, RepeatableInterface
+{
+    private const TABLE_NAME = 'sys_file';
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool
+    ) {}
+
+    /**
+     * @return string Title of this updater
+     */
+    public function getTitle(): string
+    {
+        return 'Update "mime_type" field to extension specific types';
+    }
+
+    /**
+     * @return string Longer description of this updater
+     * @throws \RuntimeException
+     */
+    public function getDescription(): string
+    {
+        $count = 0;
+        $description = '';
+        foreach ($this->getMimeTypesThatNeedUpdate() as $info) {
+            $count += $info['count'];
+            $description .= LF . sprintf(
+                    '*.%s: %s => %s (affects %d rows)',
+                    $info['extension'],
+                    $info['currentMimeType'],
+                    $info['newMimeType'],
+                    $info['count'],
+                );
+        }
+
+        return sprintf(
+            'Update %d records to set proper "mime_type":%s',
+            $count,
+            $description
+        );
+    }
+
+    /**
+     * @return list<array{count: int, extension: string, currentMimeType: string, newMimeType: string}>
+     */
+    protected function getMimeTypesThatNeedUpdate(): array
+    {
+        $qb = $this->getPreparedQueryBuilder();
+
+        $mimeTypeCompatibility = (new MimeTypeCompatibilityTypeGuesser())->getMimeTypeCompatibilityList();
+
+        $conditions = [];
+        foreach ($mimeTypeCompatibility as $currentMimeType => $map) {
+            foreach ($map as $extension => $newMimeType) {
+                $conditions[] = $qb->expr()->and(
+                    $qb->expr()->eq(
+                        'extension',
+                        $qb->createNamedParameter($extension)
+                    ),
+                    $qb->expr()->eq(
+                        'mime_type',
+                        $qb->createNamedParameter($currentMimeType)
+                    ),
+                );
+            }
+        }
+
+        $result = $qb
+            ->select('mime_type', 'extension')
+            ->addSelectLiteral($qb->expr()->count(self::TABLE_NAME . '.uid', 'count'))
+            ->from(self::TABLE_NAME)
+            ->where(
+                $qb->expr()->or(...$conditions)
+            )
+            ->groupBy('mime_type', 'extension')
+            ->executeQuery();
+
+        $info = [];
+        while ($row = $result->fetchAssociative()) {
+            $newMimeType = $mimeTypeCompatibility[$row['mime_type']][mb_strtolower($row['extension'])] ?? null;
+            if ($newMimeType === null) {
+                throw new \LogicException('Invalid query result, misses matching mime_type', 1747912272);
+            }
+            $info[] = [
+                'count' => (int)$row['count'],
+                'extension' => $row['extension'],
+                'currentMimeType' => $row['mime_type'],
+                'newMimeType' => $newMimeType,
+            ];
+        }
+
+        return $info;
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->getMimeTypesThatNeedUpdate() !== [];
+    }
+
+    /**
+     * @return string[] All new fields and tables must exist
+     */
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    public function executeUpdate(): bool
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
+        foreach ($this->getMimeTypesThatNeedUpdate() as $info) {
+            $currentMimeType = $info['currentMimeType'];
+            $extension = $info['extension'];
+            $newMimeType = $info['newMimeType'];
+
+            $connection->update(
+                self::TABLE_NAME,
+                ['mime_type' => $newMimeType],
+                ['mime_type' => $currentMimeType, 'extension' => $extension],
+            );
+        }
+
+        return true;
+    }
+
+    private function getPreparedQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll();
+        return $queryBuilder;
+    }
+}

--- a/Classes/Upgrades/v13/SysFileMountIdentifierMigration.php
+++ b/Classes/Upgrades/v13/SysFileMountIdentifierMigration.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Upgrades\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+
+/**
+ * @since 12.1
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('sysFileMountIdentifierMigration')]
+class SysFileMountIdentifierMigration implements UpgradeWizardInterface
+{
+    protected const TABLE_NAME = 'sys_filemounts';
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    public function getTitle(): string
+    {
+        return 'Migrate base and path to the new identifier property of the "sys_filemounts" table.';
+    }
+
+    public function getDescription(): string
+    {
+        return 'The "sys_filemounts" table has a new identifier property which is used to identify the mount point. This update migrates the properties "base" and "path" to the new "identifier" property.';
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->columnsExistInTable() && $this->hasRecordsToUpdate();
+    }
+
+    public function executeUpdate(): bool
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME);
+
+        foreach ($this->getRecordsToUpdate() as $record) {
+            $connection->update(
+                self::TABLE_NAME,
+                ['identifier' => $record['base'] . ':' . $record['path']],
+                ['uid' => (int)$record['uid']]
+            );
+        }
+
+        return true;
+    }
+
+    protected function columnsExistInTable(): bool
+    {
+        $schemaManager = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME)->createSchemaManager();
+
+        $tableColumns = $schemaManager->listTableColumns(self::TABLE_NAME);
+
+        foreach (['path', 'base', 'identifier'] as $column) {
+            if (!isset($tableColumns[$column])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function hasRecordsToUpdate(): bool
+    {
+        return (bool)$this->getPreparedQueryBuilder()->count('uid')->executeQuery()->fetchOne();
+    }
+
+    protected function getRecordsToUpdate(): array
+    {
+        return $this->getPreparedQueryBuilder()->select(...['uid', 'path', 'base'])->executeQuery()->fetchAllAssociative();
+    }
+
+    protected function getPreparedQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->gt('base', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->neq('path', $queryBuilder->createNamedParameter('')),
+                $queryBuilder->expr()->or(
+                    $queryBuilder->expr()->eq('identifier', $queryBuilder->createNamedParameter('')),
+                    $queryBuilder->expr()->isNull('identifier'),
+                ),
+            );
+
+        return $queryBuilder;
+    }
+
+    protected function getConnectionPool(): ConnectionPool
+    {
+        return $this->connectionPool;
+    }
+}

--- a/Classes/Upgrades/v13/SysLogSerializationUpdate.php
+++ b/Classes/Upgrades/v13/SysLogSerializationUpdate.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Attribute\UpgradeWizard;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Log\LogDataTrait;
+use TYPO3\CMS\Core\Upgrades\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+
+/**
+ * @since 12.1
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('sysLogSerialization')]
+class SysLogSerializationUpdate implements UpgradeWizardInterface
+{
+    use LogDataTrait;
+    private const TABLE_NAME = 'sys_log';
+    public function __construct(private readonly ConnectionPool $connectionPool)
+    {
+    }
+
+    public function getTitle(): string
+    {
+        return 'Migrate sys_log entries to a JSON formatted value.';
+    }
+
+    public function getDescription(): string
+    {
+        return 'All sys_log_entries are now updated to contain JSON values in the "log_data" field.';
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    public function updateNecessary(): bool
+    {
+        return $this->hasRecordsToUpdate();
+    }
+
+    public function executeUpdate(): bool
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME);
+
+        // Perform fast update of a:0:{}, since it evaluates to []
+        $connection->update(
+            self::TABLE_NAME,
+            ['log_data' => '[]'],
+            ['log_data' => 'a:0:{}']
+        );
+
+        // Perform fast update of a:1:{i:0;s:0:"";}, since it evaluates to [""]
+        $connection->update(
+            self::TABLE_NAME,
+            ['log_data' => '[""]'],
+            ['log_data' => 'a:1:{i:0;s:0:"";}']
+        );
+
+        $queryBuilder = $this->getPreparedQueryBuilder();
+        $result = $queryBuilder
+            ->select('uid', 'log_data')
+            ->where(
+                $queryBuilder->expr()->like('log_data', $queryBuilder->createNamedParameter('a:%'))
+            )
+            ->executeQuery();
+        while ($record = $result->fetchAssociative()) {
+            $logData = $this->unserializeLogData($record['log_data'] ?? '');
+            $connection->update(
+                self::TABLE_NAME,
+                ['log_data' => json_encode($logData)],
+                ['uid' => (int)$record['uid']]
+            );
+        }
+
+        return true;
+    }
+
+    protected function hasRecordsToUpdate(): bool
+    {
+        $queryBuilder = $this->getPreparedQueryBuilder();
+        $record = $queryBuilder
+            ->select('uid')
+            ->where(
+                $queryBuilder->expr()->like('log_data', $queryBuilder->createNamedParameter('a:%'))
+            )
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+        return $record !== false;
+    }
+
+    protected function getPreparedQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->from(self::TABLE_NAME);
+        return $queryBuilder;
+    }
+
+    protected function getConnectionPool(): ConnectionPool
+    {
+        return $this->connectionPool;
+    }
+}

--- a/Classes/Upgrades/v13/SysTemplateNoWorkspaceMigration.php
+++ b/Classes/Upgrades/v13/SysTemplateNoWorkspaceMigration.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+namespace TYPO3\CMS\v13\Core\Upgrades;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DeletedRestriction;
+use TYPO3\CMS\Core\Upgrades\DatabaseUpdatedPrerequisite;
+use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
+
+/**
+ * @since 12.1
+ * @internal This class is only meant to be used within EXT:install and is not part of the TYPO3 Core API.
+ */
+#[UpgradeWizard('sysTemplateNoWorkspaceMigration')]
+final readonly class SysTemplateNoWorkspaceMigration implements UpgradeWizardInterface
+{
+    private const TABLE_NAME = 'sys_template';
+    public function __construct(private ConnectionPool $connectionPool)
+    {
+    }
+
+    public function getTitle(): string
+    {
+        return 'Set workspace records in table "sys_template" to deleted.';
+    }
+
+    public function getDescription(): string
+    {
+        return 'Table "sys_template" is no longer workspace aware.'
+            . ' Existing database rows having field "t3ver_wsid" > 0 are set to "deleted" = 1 to not'
+            . ' leak into live when the workspace related columns are deleted.';
+    }
+
+    public function getPrerequisites(): array
+    {
+        return [
+            DatabaseUpdatedPrerequisite::class,
+        ];
+    }
+
+    public function updateNecessary(): bool
+    {
+        if (!$this->sysTemplateTableExists() || !$this->sysTemplateT3verWsidFieldExists()) {
+            return false;
+        }
+        $queryBuilder = $this->getPreparedQueryBuilder();
+        $numberOfNotDeletedWorkspaceRows = (int)$queryBuilder
+            ->count('uid')
+            ->from(self::TABLE_NAME)
+            ->where($queryBuilder->expr()->gt('t3ver_wsid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchOne();
+        return $numberOfNotDeletedWorkspaceRows > 0;
+    }
+
+    public function executeUpdate(): bool
+    {
+        if (!$this->sysTemplateTableExists() || !$this->sysTemplateT3verWsidFieldExists()) {
+            return true;
+        }
+        $queryBuilder = $this->getPreparedQueryBuilder();
+        $queryBuilder->update(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->gt('t3ver_wsid', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->set('deleted', 1, true, Connection::PARAM_INT)
+            ->executeStatement();
+        return true;
+    }
+
+    private function sysTemplateTableExists(): bool
+    {
+        $schemaManager = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME)->createSchemaManager();
+        return $schemaManager->tablesExist([self::TABLE_NAME]);
+    }
+
+    private function sysTemplateT3verWsidFieldExists(): bool
+    {
+        $schemaManager = $this->getConnectionPool()->getConnectionForTable(self::TABLE_NAME)->createSchemaManager();
+        $tableColumns = $schemaManager->listTableColumns(self::TABLE_NAME);
+        $fieldExists = false;
+        foreach ($tableColumns as $column) {
+            if ($column->getName() === 't3ver_wsid') {
+                $fieldExists = true;
+                break;
+            }
+        }
+        return $fieldExists;
+    }
+
+    private function getPreparedQueryBuilder(): QueryBuilder
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::TABLE_NAME);
+        $queryBuilder->getRestrictions()->removeAll()->add(new DeletedRestriction());
+        return $queryBuilder;
+    }
+
+    private function getConnectionPool(): ConnectionPool
+    {
+        return $this->connectionPool;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -29,3 +29,6 @@ services:
 
   TYPO3\CMS\v12\Core\Upgrades\:
     resource: '../Classes/Upgrades/v12/*'
+
+  TYPO3\CMS\v13\Core\Upgrades\:
+    resource: '../Classes/Upgrades/v13/*'

--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/wapplersystems/core-upgrader.svg)](https://packagist.org/packages/ichhabrecht/core-upgrader)
 
-Run upgrade wizards for multiple TYPO3 versions (to 13.4) at once.
+Run upgrade wizards for multiple TYPO3 versions in one migration flow.
 
 ## Features
 
-This extension allows to upgrade the TYPO3 core from v7.6 to v11.5 with this extension and the rest by the v13 core in one step.
+This extension allows to execute legacy/core migration steps in one flow.
+
+### v14 status in this project
+
+This repository variant is prepared for **TYPO3 v14** and contains additional adjustments for running the imported v13 wizard classes in a v14 installation.
 
 Differences from the original Core Upgrade Wizards:
 
 * The Text/Textpic/Image to Textmedia Wizard has been split into optional wizards
-* Some obsolete wizards were removed, because their result cannot be used in version 13 already.
+* Some obsolete wizards were removed, because their result cannot be used in newer TYPO3 versions.
 
 ## Installation
 
@@ -29,3 +33,16 @@ Simply install the extension with Composer or download from [TER](https://extens
 
    `typo3 upgrade:run`
 
+## Run single migrations
+
+Run one specific wizard by identifier:
+
+```bash
+typo3 upgrade:run <wizardIdentifier>
+```
+
+Examples:
+
+```bash
+typo3 upgrade:run sysLogSerialization
+```

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
             "TYPO3\\CMS\\v95\\Core\\Upgrades\\": "Classes/Upgrades/v95/",
             "TYPO3\\CMS\\v104\\Core\\Upgrades\\": "Classes/Upgrades/v104/",
             "TYPO3\\CMS\\v11\\Core\\Upgrades\\": "Classes/Upgrades/v11/",
-            "TYPO3\\CMS\\v12\\Core\\Upgrades\\": "Classes/Upgrades/v12/"
+            "TYPO3\\CMS\\v12\\Core\\Upgrades\\": "Classes/Upgrades/v12/",
+            "TYPO3\\CMS\\v13\\Core\\Upgrades\\": "Classes/Upgrades/v13/"
         }
     },
     "extra": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /***************************************************************
  * Extension Manager/Repository config file for ext "core_upgrader2".
  *
@@ -9,7 +11,6 @@
  * Only the data in the array - everything else is removed by next
  * writing. "version" and "dependencies" must not be touched!
  ***************************************************************/
-
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Core upgrader',
     'description' => 'Run upgrade wizards for multiple TYPO3 versions at once and clean up the system',
@@ -21,8 +22,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '13.0.1',
     'constraints' => [
         'depends' => [
-            'typo3' => '14.0.0-14.4.99',
+            'typo3' => '14.0.0-14.3.99',
         ],
     ],
 ];
-


### PR DESCRIPTION
- import and register v13 upgrade wizards in core_upgrader
- fix RowUpdater instantiation for v14 by making SysRedirectRootPageMoveMigration  constructable without mandatory constructor args
- update README with TYPO3 v14 context and examples for running single migrations